### PR TITLE
Setting default timezone if not set.

### DIFF
--- a/src/PatternLab/Faker/PatternLabListener.php
+++ b/src/PatternLab/Faker/PatternLabListener.php
@@ -35,6 +35,11 @@ class PatternLabListener extends \PatternLab\Listener {
     $locale = ($locale) ? $locale : "en_US";
     $this->locale = $locale;
     
+    // set-up time zone if not already set to prevent errors in PHP 5.4+
+    if (!ini_get('date.timezone')) {
+      date_default_timezone_set('UTC');
+    }
+    
     // set-up Faker
     $this->faker = \Faker\Factory::create($locale);
     $this->faker->addProvider(new \Faker\Provider\Color($this->faker));


### PR DESCRIPTION
This prevent errors in PHP 5.4+ that give this message:

```
Warning: strtotime(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone.
```

Call stack errors:

<details>

``` bash
Warning: strtotime(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/fzaninotto/faker/src/Faker/Provider/DateTime.php on line 19

Call Stack:
    0.0022     242728   1. {main}() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/core/console:0
    0.0246    4151080   2. PatternLab\Console::run() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/core/console:46
    0.0272    4383296   3. PatternLab\Console\Commands\GenerateCommand->run() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/pattern-lab/core/src/PatternLab/Console.php:91
    0.0475    5997128   4. PatternLab\Generator->generate() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/pattern-lab/core/src/PatternLab/Console/Commands/GenerateCommand.php:42
    0.0521    6393904   5. PatternLab\PatternData::gather() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/pattern-lab/core/src/PatternLab/Generator.php:69
    0.0740    7502704   6. Symfony\Component\EventDispatcher\EventDispatcher->dispatch() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/pattern-lab/core/src/PatternLab/PatternData.php:150
    0.0741    7503296   7. Symfony\Component\EventDispatcher\EventDispatcher->doDispatch() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/symfony/event-dispatcher/EventDispatcher.php:43
    0.0741    7503680   8. call_user_func:{/Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/symfony/event-dispatcher/EventDispatcher.php:174}() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/symfony/event-dispatcher/EventDispatcher.php:174
    0.0741    7503800   9. PatternLab\Faker\PatternLabListener->fakeContent() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/symfony/event-dispatcher/EventDispatcher.php:174
    0.0742    7503888  10. PatternLab\Faker\PatternLabListener->recursiveWalk() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/pattern-lab/plugin-faker/src/PatternLab/Faker/PatternLabListener.php:111
    0.0796    7732240  11. PatternLab\Faker\PatternLabListener->recursiveWalk() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/pattern-lab/plugin-faker/src/PatternLab/Faker/PatternLabListener.php:178
    0.0796    7732728  12. PatternLab\Faker\PatternLabListener->compareReplaceFaker() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/pattern-lab/plugin-faker/src/PatternLab/Faker/PatternLabListener.php:180
    0.0796    7733464  13. Faker\Generator->__get() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/pattern-lab/plugin-faker/src/PatternLab/Faker/PatternLabListener.php:95
    0.0796    7733464  14. Faker\Generator->format() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/fzaninotto/faker/src/Faker/Generator.php:238
    0.0796    7734144  15. call_user_func_array:{/Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/fzaninotto/faker/src/Faker/Generator.php:196}() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/fzaninotto/faker/src/Faker/Generator.php:196
    0.0796    7734360  16. Faker\Provider\DateTime->monthName() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/fzaninotto/faker/src/Faker/Generator.php:196
    0.0796    7734480  17. Faker\Provider\DateTime::dateTime() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/fzaninotto/faker/src/Faker/Provider/DateTime.php:255
    0.0796    7734680  18. Faker\Provider\DateTime::unixTime() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/fzaninotto/faker/src/Faker/Provider/DateTime.php:48
    0.0796    7734784  19. Faker\Provider\DateTime::getMaxTimestamp() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/fzaninotto/faker/src/Faker/Provider/DateTime.php:32
    0.0796    7734832  20. strtotime() /Users/Evan/dev/p2/dev-tools/theme-tools/pattern-lab-starter/pattern-lab/vendor/fzaninotto/faker/src/Faker/Provider/DateTime.php:19
```

</details
